### PR TITLE
remove unnecessary prints

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -481,7 +481,7 @@ func DumpHelper(v Node, source []byte, level int, kv map[string]string, cb func(
 	name := v.Kind().String()
 	indent := strings.Repeat("    ", level)
 	fmt.Printf("%s%s {\n", indent, name)
-	indent2 := strings.Repeat("    ", level+1)
+	// indent2 := strings.Repeat("    ", level+1)
 	// if v.Type() == TypeBlock {
 	// 	fmt.Printf("%sRawText: \"", indent2)
 	// 	for i := 0; i < v.Lines().Len(); i++ {
@@ -491,9 +491,9 @@ func DumpHelper(v Node, source []byte, level int, kv map[string]string, cb func(
 	// 	fmt.Printf("\"\n")
 	// 	fmt.Printf("%sHasBlankPreviousLines: %v\n", indent2, v.HasBlankPreviousLines())
 	// }
-	for name, value := range kv {
-		fmt.Printf("%s%s: %s\n", indent2, name, value)
-	}
+	// for name, value := range kv {
+	// 	fmt.Printf("%s%s: %s\n", indent2, name, value)
+	// }
 
 	if cb != nil {
 		cb(level + 1)
@@ -502,7 +502,7 @@ func DumpHelper(v Node, source []byte, level int, kv map[string]string, cb func(
 	for c := v.FirstChild(); c != nil; c = c.NextSibling() {
 		c.Dump(source, level+1)
 	}
-	fmt.Printf("%s}\n", indent)
+	// fmt.Printf("%s}\n", indent)
 }
 
 // WalkStatus represents a current status of the Walk function.

--- a/ini_tag.go
+++ b/ini_tag.go
@@ -2,7 +2,6 @@ package ini
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -16,7 +15,6 @@ func Unmarshal(data []byte, v interface{}) error {
 
 	mp := New().Load(data).Marshal2Map()
 
-	fmt.Println("map:", mp)
 	bindTag("ini", v, mp)
 	return nil
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -27,6 +27,8 @@ func (this *Scanner) Scan() {
 
 	doc, err := this.p.ParseDocument()
 
-	fmt.Println("err:", err)
+	if err != nil {
+		fmt.Println("err:", err)
+	}
 	doc.DumpV2()
 }


### PR DESCRIPTION
Hello,

This PR is aimed to remove prints when calling ini.Unmarshal
Related issue: #2 

Since ini files quite often used as configuration format in daemon software, having library that messes stdout is not good.

Sincerely,
mykola2312